### PR TITLE
Fix frontend routing for direct links and refreshes by adding custom NGINX config

### DIFF
--- a/legisloop-frontend/Dockerfile
+++ b/legisloop-frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/legisloop-frontend/default.conf
+++ b/legisloop-frontend/default.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
This PR fixes 404 errors when refreshing or directly navigating to React Router routes (e.g., /legislation/:id, /connect).
- Added a custom default.conf to the frontend container.
- Updated Dockerfile to copy the config at build time.
- NGINX now falls back to index.html for unknown paths.

This ensures direct links and refreshes work correctly across the app.